### PR TITLE
remove obsolete "@kadira/storybook": "^1.19.0" from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "publish-storybook": "bash .scripts/publish_storybook.sh"
   },
   "devDependencies": {
-    "@kadira/storybook": "^1.19.0",
     "babel-cli": "^6.5.0",
     "babel-core": "^6.5.0",
     "babel-eslint": "^6.0.2",


### PR DESCRIPTION
removes obsolete "@kadira/storybook": "^1.19.0" from devDependencies

It causes installing extraneous version of storybook-ui