### PR TITLE
add shelljs ver of prepublish script

### DIFF
--- a/.scripts/prepublish.js
+++ b/.scripts/prepublish.js
@@ -13,11 +13,10 @@ const args = [
 ].join(' ');
 
 const cmd = `${babel} ${args}`;
-shell.echo(chalk.gray(cmd));
 shell.rm('-rf', 'dist');
 
+shell.echo(chalk.gray('\n=> Transpiling \'src\' into ES5 ...\n'));
+shell.echo(chalk.gray(cmd));
 shell.echo('');
-shell.echo(chalk.gray('=> Transpiling \'src\' into ES5 ...'));
 shell.exec(cmd);
-shell.echo(chalk.gray('=> Transpiling completed.'));
-shell.echo('');
+shell.echo(chalk.gray('\n=> Transpiling completed.'));

--- a/.scripts/prepublish.js
+++ b/.scripts/prepublish.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const shell = require('shelljs');
+const chalk = require('chalk');
+const babel = ['node_modules', '.bin', 'babel'].join(path.sep);
+
+require('./ver');
+
+
+const args = [
+  '--ignore tests,__tests__,stories,story.jsx,story.js',
+  '--plugins "transform-runtime"',
+  './src --out-dir ./dist',
+].join(' ');
+
+const cmd = `${babel} ${args}`;
+shell.echo(chalk.gray(cmd));
+shell.rm('-rf', 'dist');
+
+shell.echo('');
+shell.echo(chalk.gray('=> Transpiling \'src\' into ES5 ...'));
+shell.exec(cmd);
+shell.echo(chalk.gray('=> Transpiling completed.'));
+shell.echo('');

--- a/.scripts/ver.js
+++ b/.scripts/ver.js
@@ -1,0 +1,5 @@
+const shell = require('shelljs');
+const chalk = require('chalk');
+const packageJson = require('../package.json');
+
+shell.echo(chalk.bold(`${packageJson.name}@${packageJson.version}`));

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.5.0",
+    "chalk": "^1.1.3",
     "enzyme": "^2.2.0",
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "prepublish": ". ./.scripts/prepublish.sh",
+    "prepublish": "node .scripts/prepublish.js",
     "lint": "eslint src",
     "lintfix": "eslint src --fix",
     "testonly": "mocha --require .scripts/mocha_runner src/**/__tests__/**/*.js",


### PR DESCRIPTION
this adds shelljs version of prepublish script

instead of #76 